### PR TITLE
Open the browser using a goroutine, as this prevents the call from blocking execution

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,10 +91,12 @@ func main() {
 	log.Info("Requesting Access Token from Dataporten")
 
 	// Open browser to authenticate user and get access token
-	err = browser.OpenURL(authURL + "?response_type=token&client_id=" + cluster.ClientID)
-	if err != nil {
-		log.Fatal("Failed in opening browser ", err)
-	}
+	go func(dataportenAuthURL string) {
+		err = browser.OpenURL(dataportenAuthURL)
+		if err != nil {
+			log.Fatal("Failed in opening browser ", err)
+		}
+	} (authURL + "?response_type=token&client_id=" + cluster.ClientID)
 
 	token, err := getToken(cluster.Port)
 	if err != nil {


### PR DESCRIPTION
In some environments the call to OpenURL would block further execution, causing the token server not to start, and thus preventing the program from continuing.