### PR TITLE
Console login default namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ go:
 before_install:
 - mkdir -p $GOPATH/bin
 - curl https://glide.sh/get | sh
-- mv $GOPATH/src/github.com/UNINETT $GOPATH/src/github.com/uninett
-- cd $GOPATH/src/github.com/uninett/kubed
+- cd $TRAVIS_BUILD_DIR
 - glide install
 deploy:
   provider: releases

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -32,6 +32,9 @@ type KubeConfigSetup struct {
 
 	// kubeConfigFile is the path where the kube config is stored
 	kubeConfigFile string
+
+	// NameSpace is the default namespace used with kubectl. May be blank.
+	NameSpace string
 }
 
 // SetupKubeconfig reads config from disk, adds the minikube settings, and writes it back.
@@ -61,6 +64,9 @@ func SetupKubeConfig(cfg *KubeConfigSetup) error {
 	context := api.NewContext()
 	context.Cluster = cfg.ClusterName
 	context.AuthInfo = userName
+	if (cfg.NameSpace != "") {
+		context.Namespace = cfg.NameSpace
+	}
 	config.Contexts[contextName] = context
 
 	// Only set current context to minikube if the user has not used the keepContext flag

--- a/kubedconf.go
+++ b/kubedconf.go
@@ -17,6 +17,7 @@ type Cluster struct {
 	KubeConfig  string `yaml:"kubeconfig"`
 	KeepContext bool   `yaml:"keepcontext"`
 	Port        int    `yaml:"port"`
+	ManualInput bool   `yaml:"manualinput"`
 }
 
 func readConfig(name string) (*Cluster, error) {
@@ -49,7 +50,8 @@ func setConfig(
 	client_id string,
 	kubeconfig string,
 	keepContext bool,
-	port int) *Cluster {
+	port int,
+	manual_input bool) *Cluster {
 
 	return &Cluster{
 		Name:        name,
@@ -59,6 +61,7 @@ func setConfig(
 		KubeConfig:  kubeconfig,
 		KeepContext: keepContext,
 		Port:        port,
+		ManualInput: manual_input,
 	}
 }
 

--- a/kubedconf.go
+++ b/kubedconf.go
@@ -17,6 +17,7 @@ type Cluster struct {
 	KubeConfig  string `yaml:"kubeconfig"`
 	KeepContext bool   `yaml:"keepcontext"`
 	Port        int    `yaml:"port"`
+	NameSpace   string `yaml:"namespace"`
 	ManualInput bool   `yaml:"manualinput"`
 }
 
@@ -51,6 +52,7 @@ func setConfig(
 	kubeconfig string,
 	keepContext bool,
 	port int,
+	namespace string,
 	manual_input bool) *Cluster {
 
 	return &Cluster{
@@ -61,6 +63,7 @@ func setConfig(
 		KubeConfig:  kubeconfig,
 		KeepContext: keepContext,
 		Port:        port,
+		NameSpace:   namespace,
 		ManualInput: manual_input,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	port        = flag.Int("port", 49999, "Port number where Oauth2 Provider will redirect Kubed")
 	renew       = flag.String("renew", "", "Name of the cluster to renew JWT token for")
 	client_id   = flag.String("client-id", "", "Client ID for Kubed app (Required)")
+	namespace   = flag.String("namespace", "", "Default namespace to use (optional)")
 	manual_input= flag.Bool("manual-input", false, "Input authentication token manually (no local browser)")
 	version     = "none"
 	reqErr      error
@@ -72,6 +73,7 @@ func main() {
 			*kubeconfig,
 			*keepContext,
 			*port,
+			*namespace,
 			*manual_input)
 
 		// Check if we have all the required parameters
@@ -136,6 +138,7 @@ func main() {
 	cfg.ClusterServerAddress = cluster.APIServer
 	cfg.kubeConfigFile = cluster.KubeConfig
 	cfg.KeepContext = cluster.KeepContext
+	cfg.NameSpace = cluster.NameSpace
 
 	err = SetupKubeConfig(cfg)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -101,11 +101,11 @@ func main() {
 	if (cluster.ManualInput) {
 		fmt.Println("Open a browser and navigate to " + authURL + "?response_type=token&client_id=" + cluster.ClientID)
         fmt.Println("After authentication, you are redirected to an invalid URL. Copy/paste this url below:")
-		fmt.Print("Redirect-URL: ")
+		fmt.Print("Redirected URL: ")
         token_url_string := ""
 		token_url_string, err = bufio.NewReader(os.Stdin).ReadString('\n')
         if err != nil {
-                log.Fatal("Something disastrous happened while getting input from console ", err)
+                log.Fatal("Something disastrous happened while getting input from console, please run kubed again ", err)
         }
         hash_at:=strings.Index(token_url_string,"#")
         full_hash := token_url_string[hash_at+1:len(token_url_string)]

--- a/main.go
+++ b/main.go
@@ -99,10 +99,23 @@ func main() {
 
 	// Manually fetch token if browser is unavailable from console:
 	if (cluster.ManualInput) {
-		fmt.Println("Open a browser and navigate to " + authURL + "?response_type=token&client_id=" + cluster.ClientID + ", then report the return token below.")
-		fmt.Print("access_token from redirect url: ")
-		token, err = bufio.NewReader(os.Stdin).ReadString('\n')
-		token = token[:len(token)-1]
+		fmt.Println("Open a browser and navigate to " + authURL + "?response_type=token&client_id=" + cluster.ClientID)
+        fmt.Println("After authentication, you are redirected to an invalid URL. Copy/paste this url below:")
+		fmt.Print("Redirect-URL: ")
+        token_url_string := ""
+		token_url_string, err = bufio.NewReader(os.Stdin).ReadString('\n')
+        if err != nil {
+                log.Fatal("Something disastrous happened while getting input from console ", err)
+        }
+        hash_at:=strings.Index(token_url_string,"#")
+        full_hash := token_url_string[hash_at+1:len(token_url_string)]
+        hashes:=strings.Split(full_hash,"&")
+        for _,hash := range hashes {
+            key_value := strings.Split(hash,"=")
+            if key_value[0] == "access_token" {
+                token = key_value[1]
+            }
+        }
 	// Open browser to authenticate user and get access token otherwise:
 	} else {
 		go func(dataportenAuthURL string) {

--- a/main.go
+++ b/main.go
@@ -96,13 +96,15 @@ func main() {
 	log.Info("Requesting Access Token from Dataporten")
 	err = nil
 	token := ""
+
+	// Manually fetch token if browser is unavailable from console:
 	if (cluster.ManualInput) {
 		fmt.Println("Open a browser and navigate to " + authURL + "?response_type=token&client_id=" + cluster.ClientID + ", then report the return token below.")
-		fmt.Print("Token: ")
+		fmt.Print("access_token from redirect url: ")
 		token, err = bufio.NewReader(os.Stdin).ReadString('\n')
 		token = token[:len(token)-1]
+	// Open browser to authenticate user and get access token otherwise:
 	} else {
-		// Open browser to authenticate user and get access token
 		go func(dataportenAuthURL string) {
 			err = browser.OpenURL(dataportenAuthURL)
 			if err != nil {

--- a/token.go
+++ b/token.go
@@ -71,5 +71,10 @@ func getToken(port int) (string, error) {
 
 	token := <-done
 
+   	err := srv.Close()
+	if err != nil {
+		return token, errors.Wrap(err, "Error shutting down server")
+	}
+
 	return token, nil
 }

--- a/token.go
+++ b/token.go
@@ -71,9 +71,5 @@ func getToken(port int) (string, error) {
 
 	token := <-done
 
-	err := srv.Close()
-	if err != nil {
-		return token, errors.Wrap(err, "Error shutting down server")
-	}
 	return token, nil
 }


### PR DESCRIPTION
I've added a few functionalities which may be of interest. 

1) Enabling a console version of the token handling. I mostly work in remote consoles, and then it becomes difficult to open a functional js-enabled browser from the shell. -manual-input enables copy-pasting the token request url, and pasting back the authetication token upon redirect. I'm not sure if it is possible to make this more elegant from the server side - if so I'd love to know how to adapt to it.

2) Enabled adding a default namespace to the kube config. Super handy if your work is mostly related to one specific namespace.

Both functionalities store their parameters in kubedconf so it's compatible with a -renew command.